### PR TITLE
Refact Remote Kernel Connection UI

### DIFF
--- a/src/remote-kernel.ts
+++ b/src/remote-kernel.ts
@@ -153,6 +153,10 @@ export namespace RemoteKernelActions {
       wsUrl: clientSettings.wsUrl
     };
 
+    if (!sessionContext.kernelDisplayStatus) {
+      await sessionContext.changeKernel({ name: 'python3' });
+    }
+
     const settings = ServerConnection.makeSettings();
     const kernel = await KernelAPI.startNew({ name: 'python3' }, settings);
 
@@ -184,7 +188,11 @@ export namespace RemoteKernelActions {
         });
 
         Private.setConnectionStatus(false);
-        Private.setCurrentKernel(sessionContext.session.kernel.id);
+        Private.setCurrentKernel(
+          sessionContext.kernelDisplayStatus
+            ? sessionContext.session.kernel.id
+            : null
+        );
       }
     });
   };

--- a/src/remote-kernel.ts
+++ b/src/remote-kernel.ts
@@ -89,11 +89,11 @@ export namespace RemoteKernelActions {
         });
       });
 
-    // Keep tracking of the previous kernel
-    let previousKernel = notebookPanel.sessionContext.session.kernel.id;
+    // Keep tracking of the current kernel
+    let currentKernel = notebookPanel.sessionContext.session.kernel.id;
 
     notebookPanel.sessionContext.kernelChanged.connect(async () => {
-      if (previousKernel === kernel.id) {
+      if (currentKernel === kernel.id) {
         const dialogResult = await showDialogBase({
           title: 'Remote Kernel Has Been Disconnected',
           body: 'This session is no longer connected to a remote kernel.',
@@ -102,7 +102,7 @@ export namespace RemoteKernelActions {
             Dialog.okButton()
           ]
         });
-        previousKernel = notebookPanel.sessionContext.session.kernel.id;
+        currentKernel = notebookPanel.sessionContext.session.kernel.id;
 
         if (dialogResult.button.label === 'Reconnect') {
           void setConnection(parameter, notebookPanel);

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -5,5 +5,5 @@ declare module '*.svg' {
 
 declare module '*.png' {
   const value: any;
-  export = value;
+  export default value;
 }

--- a/src/widget-extensions.ts
+++ b/src/widget-extensions.ts
@@ -10,9 +10,7 @@ import { setDatasetIcon, DatasetActions } from './dataset';
 
 import { setParameterIcon, ParameterActions } from './parameter';
 
-import { LocalKernelActions } from './local-kernel';
-
-import { kernelIcon } from '@jupyterlab/ui-components';
+import { RemoteKernelActions } from './remote-kernel';
 
 /**
  * A notebook widget extension that adds buttons to the toolbar.
@@ -45,19 +43,18 @@ export class ToolbarWidgetExtension
 
     panel.toolbar.insertAfter('setDataset', 'setParameter', parameter);
 
-    // adds a toolbarbutton for local kernel connection declaration
+    // adds a toolbarbutton for remote kernel connection declaration
     const localKernelConnection = new ToolbarButton({
-      icon: kernelIcon,
-      label: 'Local Kernel Connection',
+      label: 'Remote Kernel Connection',
       onClick: async (): Promise<void> => {
-        LocalKernelActions.showDialog(panel);
+        RemoteKernelActions.showDialog(panel);
       },
-      tooltip: 'Connect to a Local Kernel'
+      tooltip: 'Connect to a Remote Kernel'
     });
 
     panel.toolbar.insertBefore(
       'kernelName',
-      'setLocalKernel',
+      'setRemoteKernel',
       localKernelConnection
     );
 

--- a/src/widget-extensions.ts
+++ b/src/widget-extensions.ts
@@ -43,20 +43,19 @@ export class ToolbarWidgetExtension
 
     panel.toolbar.insertAfter('setDataset', 'setParameter', parameter);
 
-    // adds a toolbarbutton for remote kernel connection declaration
-    const remoteKernelConnection = new ToolbarButton({
-      label: 'Remote Kernel Connection',
+    // adds a toolbarbutton for remote kernel connection/disconnection declaration
+    const remoteKernelButton = new ToolbarButton({
+      label: 'Remote Kernel',
       onClick: async (): Promise<void> => {
-        RemoteKernelActions.showDialog(panel);
+        RemoteKernelActions.handleAction(panel.sessionContext);
       },
-      tooltip: 'Connect to a Remote Kernel',
-      className: 'remote-kernel-connection'
+      tooltip: 'Switch between remote kernel and local kernel'
     });
 
     panel.toolbar.insertBefore(
       'kernelName',
       'setRemoteKernel',
-      remoteKernelConnection
+      remoteKernelButton
     );
 
     return new DisposableDelegate(() => {

--- a/src/widget-extensions.ts
+++ b/src/widget-extensions.ts
@@ -44,18 +44,19 @@ export class ToolbarWidgetExtension
     panel.toolbar.insertAfter('setDataset', 'setParameter', parameter);
 
     // adds a toolbarbutton for remote kernel connection declaration
-    const localKernelConnection = new ToolbarButton({
+    const remoteKernelConnection = new ToolbarButton({
       label: 'Remote Kernel Connection',
       onClick: async (): Promise<void> => {
         RemoteKernelActions.showDialog(panel);
       },
-      tooltip: 'Connect to a Remote Kernel'
+      tooltip: 'Connect to a Remote Kernel',
+      className: 'remote-kernel-connection'
     });
 
     panel.toolbar.insertBefore(
       'kernelName',
       'setRemoteKernel',
-      localKernelConnection
+      remoteKernelConnection
     );
 
     return new DisposableDelegate(() => {


### PR DESCRIPTION
- rename all "local" to "remote", since the context is in PlatIAgro's perspective
- remove remote connection button icon
- add visual connection and disconnection feedback